### PR TITLE
python script to upload owl stuff to the paramserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin
 build
 .gradle
+*.pyc

--- a/knowrob_beliefstate/CMakeLists.txt
+++ b/knowrob_beliefstate/CMakeLists.txt
@@ -10,12 +10,24 @@ project(knowrob_beliefstate)
 ##############################################################################
 
 #find_package(catkin REQUIRED rosjava_build_tools knowrob_common)
-find_package(catkin REQUIRED knowrob_common knowrob_paramserver)
+find_package(catkin REQUIRED knowrob_common knowrob_paramserver COMPONENTS message_generation)
+
+catkin_python_setup()
 
 # Set the gradle targets you want catkin's make to run by default, e.g.
 #   catkin_rosjava_setup(installApp)
 # Note that the catkin_create_rosjava_xxx scripts will usually automatically
 # add tasks to this for you when you create subprojects.
+
+add_service_files(
+   FILES
+   DirtyObject.srv
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+   DEPENDENCIES
+)
 
 #catkin_rosjava_setup(installApp publishMavenJavaPublicationToMavenRepository writeClasspath)
 

--- a/knowrob_beliefstate/package.xml
+++ b/knowrob_beliefstate/package.xml
@@ -21,7 +21,9 @@
   <build_depend>knowrob_common</build_depend>
   <build_depend>knowrob_paramserver</build_depend>
   <build_depend>knowrob_assembly</build_depend>
-
+  <build_depend>message_generation</build_depend>
+  
+  <run_depend>message_runtime</run_depend>
   <run_depend>knowrob_common</run_depend>
   <run_depend>knowrob_paramserver</run_depend>
   <run_depend>knowrob_assembly</run_depend>

--- a/knowrob_beliefstate/setup.py
+++ b/knowrob_beliefstate/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+   packages=['knowrob_paramserver'],
+   package_dir={'': 'src'}
+)
+
+setup(**d)

--- a/knowrob_beliefstate/src/knowrob_beliefstate/object_tf_publisher.py
+++ b/knowrob_beliefstate/src/knowrob_beliefstate/object_tf_publisher.py
@@ -2,82 +2,111 @@
 import rospy
 import tf
 from collections import defaultdict
+from knowrob_beliefstate.srv._DirtyObject import DirtyObject, DirtyObjectResponse
+from std_msgs.msg._ColorRGBA import ColorRGBA
 from visualization_msgs.msg._Marker import Marker
 from json_prolog import json_prolog
+
 
 class ThorinObject(object):
     def __init__(self):
         self.transform = None
         self.mesh_path = ''
+        self.color = ColorRGBA()
 
-    def add_transform(self, transform):
-        self.transform = transform
-        self.object_name = str(transform[1]).split('#')[1]
+    def update_color(self, r, g, b, a):
+        self.color = ColorRGBA()
+        self.color.r = float(r)
+        self.color.g = float(g)
+        self.color.b = float(b)
+        self.color.a = float(a)
+
+    def update_transform(self, ref_frame, object_name, translation, rotation):
+        self.transform = [ref_frame, object_name, translation, rotation]
+        self.object_name = str(object_name)
 
     def get_marker(self):
         marker = Marker()
         marker.header.frame_id = self.object_name
         marker.type = marker.MESH_RESOURCE
         marker.action = Marker.ADD
-        marker.id = 0
-        marker.ns = 'muh'
+        marker.id = 1337
+        marker.ns = self.get_short_name()
+        marker.color = self.color
+        marker.scale.x = 1
+        marker.scale.y = 1
+        marker.scale.z = 1
         marker.pose.orientation.w = 1
-        marker.mesh_resource = self.mesh_path
+        marker.mesh_resource = self.mesh_path[:-4] + '.dae'
         return marker
 
+    def get_short_name(self):
+        return self.object_name.split('#')[1]
+
+
 class ObjectTfPublisher(object):
-    def __init__(self):
+    def __init__(self, tf_frequency):
+        self.tf_frequency = tf_frequency
         self.prolog = json_prolog.Prolog()
         self.tf_broadcaster = tf.TransformBroadcaster()
         self.marker_publisher = rospy.Publisher('/visualization_marker', Marker, queue_size=10)
+        self.dirty_object_srv = rospy.Service('~dirty_object', DirtyObject, self.dirty_cb)
         self.objects = defaultdict(lambda: ThorinObject())
 
-    def load_object_ids(self):
-        query = self.prolog.query('get_known_object_ids(A)')
-        solutions = [x for x in query.solutions()]
-        if len(solutions) > 1:
-            rospy.logwarn('get_known_object_ids returned more than one list')
-        for object_id in solutions[0]['A']:
-            self.objects[object_id] = ThorinObject()
+    def dirty_cb(self, srv_msg):
+        self.load_object(srv_msg.object_id)
+        self.publish_object_frames()
+        rospy.loginfo('updated {}'.format(srv_msg.object_id))
+        r = DirtyObjectResponse()
+        r.success = True
+        return r
 
-        rospy.loginfo('Loaded object ids {}'.format(self.objects))
-        query.finish()
-
-    def get_object_transform(self, object_id):
-        # q = "get_object_transform('{}', B)".format(object_id)
-        # q = "get_object_mesh_path('{}', B)".format(object_id)
-        # q = "get_associated_transform(_, _, _, TempRei, _, 'http://knowrob.org/kb/knowrob_paramserver.owl#hasTransform', Transform)."
-        # q = "rdf_has(TempExt, paramserver:'endsAtTime', B)"
-        # q = "rdf_has(TempRei, paramserver:'temporalExtent', TempExt)"
-        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)".format(object_id)
-        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)".format(object_id)
-        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)," \
-        #     "rdf_has(TempRei, paramserver:'temporalExtent', TempExt)".format(object_id)
-
-        # print(q)
-        # query = self.prolog.query(q)
-        # solutions = [x for x in query.solutions()]
-        # print(solutions)
-        # for s in query.solutions():
-        #     print(s)
-        # query.finish()
-        return ['map', object_id, (0, 0, 0), (0, 0, 0, 1)]
-
-    def get_object_mash(self, object_id):
-        q = "get_object_mesh_path('{}', B)".format(object_id)
+    def prolog_query(self, q):
         query = self.prolog.query(q)
         solutions = [x for x in query.solutions()]
         if len(solutions) > 1:
-            rospy.logwarn('get_known_object_ids returned more than one list')
-        self.objects[object_id].mesh_path = str(solutions[0]['B'])
+            rospy.logwarn('{} returned more than one result'.format(q))
+        elif len(solutions) == 0:
+            rospy.logwarn('{} returned nothing'.format(q))
         query.finish()
-        # marker = Marker()
-        # marker.header.frame_id = self.objects[object_id]['transform']
-        # marker.type = marker.MESH_RESOURCE
+        return solutions
 
-    def load_object_transforms(self):
+    def load_objects(self):
+        self.load_object_ids()
         for object_id in self.objects.keys():
-            self.objects[object_id].add_transform(self.get_object_transform(object_id))
+            self.load_object(object_id)
+
+    def load_object(self, object_id):
+        self.load_object_transform(object_id)
+        self.load_object_mesh(object_id)
+        self.load_object_color(object_id)
+
+    def load_object_ids(self):
+        q = 'get_known_object_ids(A)'
+        solutions = self.prolog_query(q)
+        for object_id in solutions[0]['A']:
+            self.objects[object_id] = ThorinObject()
+        rospy.loginfo('Loaded object ids {}'.format(self.objects.keys()))
+
+    def load_object_color(self, object_id):
+        q = "get_object_color('{}', A)".format(object_id)
+        solutions = self.prolog_query(q)
+        self.objects[object_id].update_color(*solutions[0]['A'])
+
+    def load_object_transform(self, object_id):
+        # q = "get_object_transform('{}', A)".format(object_id)
+        # solutions = self.prolog_query(q)
+        # self.objects[object_id].update_transform('left_gripper_tool_frame', object_id, (0, 0, 0), (0, 0, 0, 1))
+        self.objects[object_id].update_transform('map', object_id, (0, 0, 0), (0, 0, 0, 1))
+
+    def load_object_mesh(self, object_id):
+        q = "get_object_mesh_path('{}', A)".format(object_id)
+        solutions = self.prolog_query(q)
+        self.objects[object_id].mesh_path = str(solutions[0]['A'])
+
+    def publish_object_markers(self):
+        for object_id, v in self.objects.items():
+            self.marker_publisher.publish(v.get_marker())
 
     def publish_object_frames(self):
         for object_id, thorin_object in self.objects.items():
@@ -88,20 +117,9 @@ class ObjectTfPublisher(object):
                                               thorin_object.object_name,
                                               ref_frame)
 
-    def load_object_shapes(self):
-        for object_id in self.objects.keys():
-            self.get_object_mash(object_id)
-
-    def publish_object_markers(self):
-        for object_id, v in self.objects.items():
-            print('{} {}'.format(object_id, v.mesh_path))
-            self.marker_publisher.publish(v.get_marker())
-
     def loop(self):
-        self.load_object_ids()
-        self.load_object_transforms()
-        self.load_object_shapes()
-        rate = rospy.Rate(1)
+        self.load_objects()
+        rate = rospy.Rate(self.tf_frequency)
         while not rospy.is_shutdown():
             self.publish_object_frames()
             self.publish_object_markers()
@@ -110,5 +128,5 @@ class ObjectTfPublisher(object):
 
 if __name__ == '__main__':
     rospy.init_node('object_tf_publisher')
-    asdf = ObjectTfPublisher()
+    asdf = ObjectTfPublisher(1)
     asdf.loop()

--- a/knowrob_beliefstate/src/knowrob_beliefstate/object_tf_publisher.py
+++ b/knowrob_beliefstate/src/knowrob_beliefstate/object_tf_publisher.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+import rospy
+import tf
+from collections import defaultdict
+from visualization_msgs.msg._Marker import Marker
+from json_prolog import json_prolog
+
+class ThorinObject(object):
+    def __init__(self):
+        self.transform = None
+        self.mesh_path = ''
+
+    def add_transform(self, transform):
+        self.transform = transform
+        self.object_name = str(transform[1]).split('#')[1]
+
+    def get_marker(self):
+        marker = Marker()
+        marker.header.frame_id = self.object_name
+        marker.type = marker.MESH_RESOURCE
+        marker.action = Marker.ADD
+        marker.id = 0
+        marker.ns = 'muh'
+        marker.pose.orientation.w = 1
+        marker.mesh_resource = self.mesh_path
+        return marker
+
+class ObjectTfPublisher(object):
+    def __init__(self):
+        self.prolog = json_prolog.Prolog()
+        self.tf_broadcaster = tf.TransformBroadcaster()
+        self.marker_publisher = rospy.Publisher('/visualization_marker', Marker, queue_size=10)
+        self.objects = defaultdict(lambda: ThorinObject())
+
+    def load_object_ids(self):
+        query = self.prolog.query('get_known_object_ids(A)')
+        solutions = [x for x in query.solutions()]
+        if len(solutions) > 1:
+            rospy.logwarn('get_known_object_ids returned more than one list')
+        for object_id in solutions[0]['A']:
+            self.objects[object_id] = ThorinObject()
+
+        rospy.loginfo('Loaded object ids {}'.format(self.objects))
+        query.finish()
+
+    def get_object_transform(self, object_id):
+        # q = "get_object_transform('{}', B)".format(object_id)
+        # q = "get_object_mesh_path('{}', B)".format(object_id)
+        # q = "get_associated_transform(_, _, _, TempRei, _, 'http://knowrob.org/kb/knowrob_paramserver.owl#hasTransform', Transform)."
+        # q = "rdf_has(TempExt, paramserver:'endsAtTime', B)"
+        # q = "rdf_has(TempRei, paramserver:'temporalExtent', TempExt)"
+        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)".format(object_id)
+        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)".format(object_id)
+        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)," \
+        #     "rdf_has(TempRei, paramserver:'temporalExtent', TempExt)".format(object_id)
+
+        # print(q)
+        # query = self.prolog.query(q)
+        # solutions = [x for x in query.solutions()]
+        # print(solutions)
+        # for s in query.solutions():
+        #     print(s)
+        # query.finish()
+        return ['map', object_id, (0, 0, 0), (0, 0, 0, 1)]
+
+    def get_object_mash(self, object_id):
+        q = "get_object_mesh_path('{}', B)".format(object_id)
+        query = self.prolog.query(q)
+        solutions = [x for x in query.solutions()]
+        if len(solutions) > 1:
+            rospy.logwarn('get_known_object_ids returned more than one list')
+        self.objects[object_id].mesh_path = str(solutions[0]['B'])
+        query.finish()
+        # marker = Marker()
+        # marker.header.frame_id = self.objects[object_id]['transform']
+        # marker.type = marker.MESH_RESOURCE
+
+    def load_object_transforms(self):
+        for object_id in self.objects.keys():
+            self.objects[object_id].add_transform(self.get_object_transform(object_id))
+
+    def publish_object_frames(self):
+        for object_id, thorin_object in self.objects.items():
+            ref_frame, object_frame, translation, rotation = thorin_object.transform
+            self.tf_broadcaster.sendTransform(translation,
+                                              rotation,
+                                              rospy.Time.now(),
+                                              thorin_object.object_name,
+                                              ref_frame)
+
+    def load_object_shapes(self):
+        for object_id in self.objects.keys():
+            self.get_object_mash(object_id)
+
+    def publish_object_markers(self):
+        for object_id, v in self.objects.items():
+            print('{} {}'.format(object_id, v.mesh_path))
+            self.marker_publisher.publish(v.get_marker())
+
+    def loop(self):
+        self.load_object_ids()
+        self.load_object_transforms()
+        self.load_object_shapes()
+        rate = rospy.Rate(1)
+        while not rospy.is_shutdown():
+            self.publish_object_frames()
+            self.publish_object_markers()
+            rate.sleep()
+
+
+if __name__ == '__main__':
+    rospy.init_node('object_tf_publisher')
+    asdf = ObjectTfPublisher()
+    asdf.loop()

--- a/knowrob_beliefstate/srv/DirtyObject.srv
+++ b/knowrob_beliefstate/srv/DirtyObject.srv
@@ -1,5 +1,7 @@
 #name of object that needs to be queried again
-string object_id
+string[] object_ids
 ---
+int32 SUCCESS=0
+int32 UNKNOWN_OBJECT=1
 #response fields
-bool success
+int32 error_code

--- a/knowrob_beliefstate/srv/DirtyObject.srv
+++ b/knowrob_beliefstate/srv/DirtyObject.srv
@@ -1,0 +1,5 @@
+#name of object that needs to be queried again
+string object_id
+---
+#response fields
+bool success

--- a/knowrob_paramserver/launch/prolog_queries.yaml
+++ b/knowrob_paramserver/launch/prolog_queries.yaml
@@ -1,0 +1,6 @@
+- param: 
+    query: "member(A, [4]), B = ['x', A]"
+    ns: "ns0"
+- param:  
+    query: "get_known_object_ids(A)"
+    ns: "ns1"

--- a/knowrob_paramserver/launch/upload_owl_to_paramserver.launch
+++ b/knowrob_paramserver/launch/upload_owl_to_paramserver.launch
@@ -1,0 +1,7 @@
+<launch>
+
+  <node name="knowrob_to_param_server" pkg="knowrob_paramserver" type="knowrob_to_param_server.py" output="screen">
+	<param name="yaml_path" value="$(find knowrob_paramserver)/launch/prolog_queries.yaml" />
+  </node>
+
+</launch>

--- a/knowrob_paramserver/launch/upload_owl_to_paramserver.launch
+++ b/knowrob_paramserver/launch/upload_owl_to_paramserver.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <node name="knowrob_to_param_server" pkg="knowrob_paramserver" type="knowrob_to_param_server.py" output="screen">
+  <node name="owl_to_param_server" pkg="knowrob_paramserver" type="owl_to_param_server.py" output="screen">
 	<param name="yaml_path" value="$(find knowrob_paramserver)/launch/prolog_queries.yaml" />
   </node>
 

--- a/knowrob_paramserver/setup.py
+++ b/knowrob_paramserver/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+   packages=['knowrob_paramserver'],
+   package_dir={'': 'src'}
+)
+
+setup(**d)

--- a/knowrob_paramserver/src/knowrob_paramserver/knowrob_to_param_server.py
+++ b/knowrob_paramserver/src/knowrob_paramserver/knowrob_to_param_server.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import yaml
+import rospy
+from json_prolog import json_prolog
+
+class KnowrobToParamserver(object):
+    def __init__(self):
+        self.prolog = json_prolog.Prolog()
+
+    def add_to_server(self, prolog_query, namespace):
+        query = self.prolog.query(prolog_query)
+        solution = query.solutions().next()
+        for k, v in solution.items():
+            rospy.set_param('{}/{}'.format(namespace, k), str(v))
+            rospy.loginfo('added {}={} to paramserver'.format(k,v))
+        query.finish()
+
+    def load_yaml(self, path):
+        with open(path, 'r') as stream:
+            rospy.loginfo('Parameters loaded from {}'.format(path))
+            yaml_dict = yaml.load(stream)
+            for param in yaml_dict:
+                param = param['param']
+                query = param['query']
+                ns = param['ns']
+                self.add_to_server(query, ns)
+
+if __name__ == '__main__':
+    rospy.init_node('knowrob_to_paramserver')
+    queries = rospy.get_param('~yaml_path', default='../../launch/prolog_queries.yaml')
+    asdf = KnowrobToParamserver()
+    asdf.load_yaml(queries)

--- a/knowrob_paramserver/src/knowrob_paramserver/owl_to_param_server.py
+++ b/knowrob_paramserver/src/knowrob_paramserver/owl_to_param_server.py
@@ -3,7 +3,7 @@ import yaml
 import rospy
 from json_prolog import json_prolog
 
-class KnowrobToParamserver(object):
+class OwlToParamserver(object):
     def __init__(self):
         self.prolog = json_prolog.Prolog()
 
@@ -26,7 +26,7 @@ class KnowrobToParamserver(object):
                 self.add_to_server(query, ns)
 
 if __name__ == '__main__':
-    rospy.init_node('knowrob_to_paramserver')
+    rospy.init_node('owl_to_paramserver')
     queries = rospy.get_param('~yaml_path', default='../../launch/prolog_queries.yaml')
-    asdf = KnowrobToParamserver()
+    asdf = OwlToParamserver()
     asdf.load_yaml(queries)


### PR DESCRIPTION
The added python script reads prolog queries from knowrob_paramserver/launch/prolog_queries.yaml and uploads the first results to the paramserver.
To test try:
`roslaunch knowrob_beliefstate beliefstate.launch`
`roslaunch knowrob_paramserver upload_owl_to_paramserver.launch`
This should add /ns0/A, /ns0/B, /ns1/A to the paramserver.