### PR TITLE
object state publisher

### DIFF
--- a/knowrob_beliefstate/CMakeLists.txt
+++ b/knowrob_beliefstate/CMakeLists.txt
@@ -51,13 +51,14 @@ catkin_package(
 
 add_library(kr_beliefstate SHARED 
 	src/kr_beliefstate.cpp)
-add_dependencies(foo knowrob_beliefstate_generate_messages_cpp)
+add_dependencies(kr_beliefstate knowrob_beliefstate_generate_messages_cpp)
 target_link_libraries(kr_beliefstate
 	${SWIPL_LIBRARIES}
 	${catkin_LIBRARIES})
 
 add_executable(krb_tf_listener
                src/tf_listener.cpp)
+add_dependencies(krb_tf_listener knowrob_beliefstate_generate_messages_cpp)
 target_link_libraries(krb_tf_listener
 	${catkin_LIBRARIES})
 

--- a/knowrob_beliefstate/CMakeLists.txt
+++ b/knowrob_beliefstate/CMakeLists.txt
@@ -11,7 +11,7 @@ project(knowrob_beliefstate)
 
 #find_package(catkin REQUIRED rosjava_build_tools knowrob_common)
 #find_package(catkin REQUIRED knowrob_common knowrob_paramserver COMPONENTS message_generation)
-find_package(catkin REQUIRED rosprolog knowrob_common knowrob_paramserver roscpp tf roslib rospack COMPONENTS message_generation)
+find_package(catkin REQUIRED COMPONENTS rosprolog knowrob_common knowrob_paramserver roscpp tf roslib rospack message_generation)
 
 catkin_python_setup()
 
@@ -51,6 +51,7 @@ catkin_package(
 
 add_library(kr_beliefstate SHARED 
 	src/kr_beliefstate.cpp)
+add_dependencies(foo knowrob_beliefstate_generate_messages_cpp)
 target_link_libraries(kr_beliefstate
 	${SWIPL_LIBRARIES}
 	${catkin_LIBRARIES})

--- a/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
+++ b/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
@@ -124,6 +124,7 @@ class ObjectStatePublisher(object):
         q = 'get_known_object_ids(A)'
         solutions = self.prolog_query(q)
         for object_id in solutions[0]['A']:
+            #TODO: remove this dirty hack when the test objects are removed from the knowledge base
             if 'Test' not in object_id:
                 self.objects[object_id] = ThorinObject()
         rospy.loginfo('Loaded object ids: {}'.format(self.objects.keys()))

--- a/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
+++ b/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
@@ -4,6 +4,7 @@ import tf
 from collections import defaultdict
 from knowrob_beliefstate.srv._DirtyObject import DirtyObject, DirtyObjectResponse
 from std_msgs.msg._ColorRGBA import ColorRGBA
+from std_srvs.srv._Trigger import Trigger, TriggerResponse
 from visualization_msgs.msg._Marker import Marker
 from json_prolog import json_prolog
 
@@ -22,6 +23,8 @@ class ThorinObject(object):
         self.color.a = float(a)
 
     def update_transform(self, ref_frame, object_name, translation, rotation):
+        ref_frame = str(ref_frame)
+        object_name = str(object_name)
         self.transform = [ref_frame, object_name, translation, rotation]
         self.object_name = str(object_name)
 
@@ -41,7 +44,8 @@ class ThorinObject(object):
         return marker
 
     def get_short_name(self):
-        return self.object_name.split('#')[1]
+        # return self.object_name.split('#')[1]
+        return self.object_name
 
 
 class ObjectTfPublisher(object):
@@ -51,7 +55,35 @@ class ObjectTfPublisher(object):
         self.tf_broadcaster = tf.TransformBroadcaster()
         self.marker_publisher = rospy.Publisher('/visualization_marker', Marker, queue_size=10)
         self.dirty_object_srv = rospy.Service('~mark_dirty_object', DirtyObject, self.dirty_cb)
+        self.test_srv = rospy.Service('~asdf', Trigger, self.test_srv_cb)
         self.objects = defaultdict(lambda: ThorinObject())
+
+    def test_srv_cb(self, srv_msg):
+        objectid = 'http://www.knowrob.org/kb/knowrob_beliefstate#TestWheel'
+        object_type = 'http://knowrob.org/kb/knowrob_assembly.owl#BasicMechanicalPart'
+        new_transform = ['map', objectid, [0.5, 0, 0.8], [0, 0, 0, 1]]
+        # sol = self.prolog_query("owl_individual_of('{}', B)".format(objectid, object_type))
+        # sol = self.prolog_query("owl_individual_of('{}', '{}')".format(objectid, object_type))
+        q = "replace_object_transforms('{}', {})".format(objectid, new_transform)
+        # sol = self.prolog_query("owl_individual_of('{}', '{}'), nth0(1, '{}', '{}')".format(objectid, object_type, new_transform,objectid))
+        # sol = self.prolog_query("nth0(1, {}, '{}')".format(new_transform,objectid))
+        # sol = self.prolog_query("owl_individual_of('{}', '{}'), "
+        #                         "nth0(1, {}, '{}'), "
+        #                         "replace_object_transforms('{}', {})".format(objectid, object_type, new_transform, objectid, objectid, new_transform))
+        # sol = self.prolog_query("assert_object_at_location('{}', '{}', {})".format(object_type, objectid, new_transform))
+        print('queue::: {}'.format(q))
+        sol = self.prolog_query(q)
+        for s in sol:
+            print(s)
+        print('---------------------------------------------------')
+        # query = self.prolog.query(q)
+        # solutions = [x for x in query.solutions()]
+        # if len(solutions) > 1:
+        #     rospy.logwarn('{} returned more than one result'.format(q))
+        # elif len(solutions) == 0:
+        #     rospy.logwarn('{} returned nothing'.format(q))
+        # query.finish()
+        return TriggerResponse()
 
     def dirty_cb(self, srv_msg):
         print(srv_msg)
@@ -103,16 +135,15 @@ class ObjectTfPublisher(object):
         self.objects[object_id].update_color(*solutions[0]['A'])
 
     def load_object_transform(self, object_id):
-        # q = "get_object_transform('{}', A)".format(object_id)
-        # q = "rdf_has(ObjectId, paramserver:'hasTransform', TempRei), temporal_extent_active(TempRei),rdf_has(TempRei, assembly:'hasReferencePart', Ref),owl_individual_of(Ref, assembly:'TemporaryGrasp'),get_associated_transform(_, _, _, TempRei, _, 'http://knowrob.org/kb/knowrob_paramserver.owl#hasTransform', Transform)."
-        # q = "temporal_extent_active(TemporalObject)"
-        # q = "rdf_has(TempRei, assembly:'hasReferencePart', Ref)"
-        # q = "rdf_has('{}', paramserver:'hasTransform', TempRei)".format(object_id)
-        # q = "owl_individual_of(Ref, assembly:'TemporaryGrasp')"
-        # solutions = self.prolog_query(q)
-        # print(solutions)
+        q = "get_object_transform('{}', A)".format(object_id)
+        # q = "temporal_extent_active(A)"
+        # q = "rdf_has(ObjectId, paramserver:'hasTransform', TempRei), temporal_extent_active(TempRei),rdf_has(TempRei, assembly:'hasReferencePart', Ref),atom_string(Ref, RefStr),'http://knowrob.org/kb/knowrob_paramserver.owl#MapFrameSymbol' == 'http://knowrob.org/kb/knowrob_paramserver.owl#MapFrameSymbol'"
+        #q = "rdf_has(ObjectId, paramserver:'hasTransform', TempRei), temporal_extent_active(TempRei),rdf_has(TempRei, assembly:'hasReferencePart', Ref)"
+        solutions = self.prolog_query(q)
+        print(solutions[0]['A'])
         # self.objects[object_id].update_transform('left_gripper_tool_frame', object_id, (0, 0, 0), (0, 0, 0, 1))
-        self.objects[object_id].update_transform('map', object_id, (0, 0, 0), (0, 0, 0, 1))
+        # self.objects[object_id].update_transform('map', object_id, (0, 0, 0), (0, 0, 0, 1))
+        self.objects[object_id].update_transform(*solutions[0]['A'])
 
     def load_object_mesh(self, object_id):
         q = "get_object_mesh_path('{}', A)".format(object_id)

--- a/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
+++ b/knowrob_beliefstate/src/knowrob_beliefstate/object_state_publisher.py
@@ -4,6 +4,7 @@ import tf
 from collections import defaultdict
 from knowrob_beliefstate.srv._DirtyObject import DirtyObject, DirtyObjectResponse, DirtyObjectRequest
 from std_msgs.msg._ColorRGBA import ColorRGBA
+from std_srvs.srv._SetBool import SetBool, SetBoolResponse
 from std_srvs.srv._Trigger import Trigger, TriggerResponse
 from visualization_msgs.msg._Marker import Marker
 from json_prolog import json_prolog
@@ -55,7 +56,7 @@ class ObjectStatePublisher(object):
         self.marker_publisher = rospy.Publisher('/visualization_marker', Marker, queue_size=10)
         self.dirty_object_srv = rospy.Service('~mark_dirty_object', DirtyObject, self.dirty_cb)
         self.objects = defaultdict(lambda: ThorinObject())
-        # self.test_srv = rospy.Service('~asdf', Trigger, self.test_srv_cb)
+        # self.test_srv = rospy.Service('~asdf', SetBool, self.test_srv_cb)
 
     # for testing purpose, can be deleted...
     # def test_srv_cb(self, srv_msg):
@@ -71,7 +72,8 @@ class ObjectStatePublisher(object):
     #     asdf = DirtyObjectRequest()
     #     asdf.object_ids = [objectid]
     #     self.dirty_cb(asdf)
-    #     return TriggerResponse()
+    #     # return TriggerResponse()
+    #     return SetBoolResponse()
 
     def dirty_cb(self, srv_msg):
         r = DirtyObjectResponse()
@@ -156,5 +158,6 @@ class ObjectStatePublisher(object):
 
 if __name__ == '__main__':
     rospy.init_node('object_state_publisher')
-    object_state_publisher = ObjectStatePublisher(1)
+    hz = rospy.get_param('~hz', default='1')
+    object_state_publisher = ObjectStatePublisher(int(hz))
     object_state_publisher.loop()

--- a/knowrob_paramserver/src/knowrob_paramserver/owl_to_param_server.py
+++ b/knowrob_paramserver/src/knowrob_paramserver/owl_to_param_server.py
@@ -5,6 +5,7 @@ from json_prolog import json_prolog
 
 class OwlToParamserver(object):
     def __init__(self):
+        rospy.wait_for_service('/json_prolog/query')
         self.prolog = json_prolog.Prolog()
 
     def add_to_server(self, prolog_query, namespace):


### PR DESCRIPTION
Use `rosrun knowrob_beliefstate object_state_publisher.py` to start the node.
It will publish tf frames for all objects returned by `get_known_object_ids` as well as markers, if the mesh path is valid.
Use the `/object_state_publisher/mark_dirty_object` service to update the transforms for a list of object ids.